### PR TITLE
Add support for arbitrarily complex JSON API filters

### DIFF
--- a/drupal/env/env.go
+++ b/drupal/env/env.go
@@ -4,6 +4,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 const (
@@ -50,6 +51,34 @@ func AssetsBaseUrlOr(defaultValue string) string {
 func GetEnvOr(envVar, defValue string) string {
 	if val, ok := getEnv(envVar, false); ok {
 		return val
+	} else {
+		return defValue
+	}
+}
+
+// Answers the value of the supplied environment variable as an integer, or the default value if unset.  This function
+// will panic if the value of the environment variable cannot be parsed as an integer.
+func GetEnvOrInt(envVar string, defValue int) int {
+	if val, ok := getEnv(envVar, false); ok {
+		if intval, err := strconv.Atoi(val); err != nil {
+			panic(fmt.Errorf("env: error formatting the value of environment variable '%s' as an integer: %w", envVar, err))
+		} else {
+			return intval
+		}
+	} else {
+		return defValue
+	}
+}
+
+// Answers the value of the supplied environment variable, or the default value if unset.  This function
+// will panic if the value of the environment variable cannot be parsed as a bool.
+func GetEnvOrBool(envVar string, defValue bool) bool {
+	if val, ok := getEnv(envVar, false); ok {
+		if boolval, err := strconv.ParseBool(val); err != nil {
+			panic(fmt.Errorf("env: error formatting the value of environment variable '%s' as a bool: %w", envVar, err))
+		} else {
+			return boolval
+		}
 	} else {
 		return defValue
 	}


### PR DESCRIPTION
The `JsonApiUrl` provides a quick and dirty means for constructing JSON API urls.  It is limited to queries that return a single result based on a single field and value, e.g.
- `filter[name]=Ansel Adams Images`
- `filter[title]=The Adventures of Sherlock Holmes`
- `filter[id]=4362433a-d2be-4500-bf50-553e7feb2360`

This PR adds the capabilities for arbitrarily complex queries by adding the `RawFilter` field to the `JsonApiUrl`.

The caller can supply any filter they wish, e.g.:
- `filter[name-group][condition][operator]=ENDS_WITH&filter[name-group][condition][path]=name&filter[name-group][condition][value]=Thumbnail Image.jpg&filter[of-group][condition][path]=field_media_of.title&filter[of-group][condition][value]=Derivative Image 04`

In addition, this PR contains convienience methods for obtaining typed values from the environment,
- `GetEnvOrInt(envVar string, defValue int) int`
- `GetEnvOrBool(envVar string, defValue bool) bool`
