### PR TITLE
Support HTTP basic auth when resolving JsonApiData references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ To obtain the parent collection referenced by a member_of relationship, you can:
     relData.MemberOf.Data.Resolve(t, &parentCol)
 ```
 
+Since version `0.0.5`, the `Resolve` method of `JsonApiData` supports HTTP basic auth.  To use it, invoke `ResolveWithBasicAuth` instead of `Resolve`, appending the non-empty username and password as arguments to the function call.
+
+For reference, it's signature is: 
+```go
+ResolveWithBasicAuth(t *testing.T, v interface{}, username string, password string)
+```
 ## Raw Filters
 
 Since version `0.0.2`
@@ -155,3 +161,5 @@ Since version `0.0.5`
 Set the `JsonApiUrl.Username` and `JsonApiUrl.Password` to execute an authenticated request.  In order to trigger HTTP Basic Auth, `JsonApiUrl.Username` must be a non-empty string.
 
 Authenticated requests may be useful when access to the resource is denied to the anonymous user, e.g. by a restricted access flag on the media.
+
+Be alert when using the `Resolve` function to retrieve related resources.  If you used HTTP basic auth to retrieve a JsonApiResponse and wish to resolve a relationship reference, you want to invoke `ResolveWithBasicAuth` instead.

--- a/drupal/jsonapi/jsonapi.go
+++ b/drupal/jsonapi/jsonapi.go
@@ -144,7 +144,11 @@ func (moo *JsonApiUrl) String() string {
 	assert.NotEmpty(moo.T, moo.DrupalEntity, "error generating a JsonAPI URL from %v: %s", moo, "drupal entity must not be empty")
 	assert.NotEmpty(moo.T, moo.DrupalBundle, "error generating a JsonAPI URL from %v: %s", moo, "drupal bundle must not be empty")
 
-	u, err = url.Parse(fmt.Sprintf("%s", strings.Join([]string{env.BaseUrlOr(moo.BaseUrl), "jsonapi", moo.DrupalEntity, moo.DrupalBundle}, "/")))
+	baseUrl := env.BaseUrlOr(moo.BaseUrl)
+	if strings.HasSuffix(baseUrl, "/") {
+		baseUrl = baseUrl[:len(baseUrl) - 1]
+	}
+	u, err = url.Parse(fmt.Sprintf("%s", strings.Join([]string{baseUrl, "jsonapi", moo.DrupalEntity, moo.DrupalBundle}, "/")))
 	assert.Nil(moo.T, err, "error generating a JsonAPI URL from %v: %s", moo, err)
 
 	// If a raw filter is supplied, use it as-is, otherwise use the .Filter and .Value

--- a/drupal/model/model.go
+++ b/drupal/model/model.go
@@ -57,11 +57,34 @@ type JsonApiData struct {
 func (jad *JsonApiData) Resolve(t *testing.T, v interface{}) {
 	u := jsonapi.JsonApiUrl{
 		T:            t,
-		BaseUrl:      env.BaseUrlOr("https://islandora-idc.traefik.me/"),
+		// TODO FIXME the BaseUrl won't work as expected. Really the caller wants the BaseUrl that was used to retrieve
+		//   the JsonApiData, which means we really need access to the JSON API 'links' object and use the 'self' href.
+		//   But we can't do that easily right now.
+		BaseUrl:      env.BaseUrlOr("https://islandora-idc.traefik.me"),
 		DrupalEntity: jad.Type.Entity(),
 		DrupalBundle: jad.Type.Bundle(),
 		Filter:       "id",
 		Value:        jad.Id,
+	}
+
+	u.GetSingle(v)
+}
+
+// ResolveWithBasicAuth behaves as Resolve, but issues the request with HTTP Basic Auth, using the supplied username and
+// password
+func (jad *JsonApiData) ResolveWithBasicAuth(t *testing.T, v interface{}, username string, password string) {
+	u := jsonapi.JsonApiUrl{
+		T:            t,
+		// TODO FIXME the BaseUrl won't work as expected. Really the caller wants the BaseUrl that was used to retrieve
+		//   the JsonApiData, which means we really need access to the JSON API 'links' object and use the 'self' href.
+		//   But we can't do that easily right now.
+		BaseUrl:      env.BaseUrlOr("https://islandora-idc.traefik.me"),
+		DrupalEntity: jad.Type.Entity(),
+		DrupalBundle: jad.Type.Bundle(),
+		Filter:       "id",
+		Value:        jad.Id,
+		Username:     username,
+		Password:     password,
 	}
 
 	u.GetSingle(v)


### PR DESCRIPTION
Importantly, this fixes an issue whereby a base URL with a trailing slash would be redirected by Drupal to a base URL sans the extra slash.  The redirect is followed, but the Authorization header is not added to the redirect, so basic authentication will fail.